### PR TITLE
Move Gemini API key validation to WeatherAgent superclass

### DIFF
--- a/pydanticai/pydantic_weather_agent.py
+++ b/pydanticai/pydantic_weather_agent.py
@@ -15,11 +15,8 @@ class PydanticWeatherAgent(WeatherAgent):
     def __init__(self):
         super().__init__("PydanticAI Weather Agent")
         
-        # Geminiモデルの設定（API キーを環境変数から取得）
-        api_key = os.getenv('GEMINI_API_KEY')
-        if not api_key:
-            raise ValueError("GEMINI_API_KEY環境変数が設定されていません")
-        
+        # Geminiモデルの設定（API キーを共通メソッドから取得）
+        api_key = self._get_gemini_api_key()
         self.model = GeminiModel(self.GEMINI_MODEL, api_key=api_key)
         
         # PydanticAI Agentの初期化

--- a/weather_agent.py
+++ b/weather_agent.py
@@ -1,3 +1,4 @@
+import os
 from abc import ABC, abstractmethod
 from typing import Dict, Any
 
@@ -17,6 +18,21 @@ class WeatherAgent(ABC):
             name: エージェントの名前
         """
         self.name = name
+    
+    def _get_gemini_api_key(self) -> str:
+        """
+        Gemini API キーを環境変数から取得する共通メソッド
+        
+        Returns:
+            API キー文字列
+            
+        Raises:
+            ValueError: API キーが設定されていない場合
+        """
+        api_key = os.getenv('GEMINI_API_KEY')
+        if not api_key:
+            raise ValueError("GEMINI_API_KEY環境変数が設定されていません")
+        return api_key
     
     @abstractmethod
     def run(self, city: str) -> str:


### PR DESCRIPTION
## Summary
- Add `_get_gemini_api_key()` method to WeatherAgent base class
- Move API key validation logic from PydanticWeatherAgent to superclass
- This allows all agent implementations (LangChain, ADK, etc.) to share the same validation logic
- Improves code reusability and consistency across different agent types

## Changes
- Added `_get_gemini_api_key()` method to `WeatherAgent` 
- Updated `PydanticWeatherAgent` to use the shared method
- Removed duplicate validation code

## Test plan
- [ ] Verify API key validation still works correctly
- [ ] Test error message when GEMINI_API_KEY is not set
- [ ] Confirm other agent types can use the shared method

🤖 Generated with [Claude Code](https://claude.ai/code)