### PR TITLE
LangChain Agentに天気API呼び出し機能を実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ agentic_workflow_examples
 サンプルアプリはコマンドラインアプリで、下記を行います
  - まずコンソールの入力として、天気を知りたい都市名を求めてきます
  - 都市名を入力すると、Google Maps Geocoding APIから経度緯度に変換します
- - 次に、経度緯度をOpenWeatherMapに渡して、天気を得ます
+ - 次に、経度緯度をGoogle Weather APIに渡して、天気を得ます
  - 天気をコマンドラインに日本語で出力して終了します
  - サンプルなので、いったんテストはいらないです
 
@@ -33,6 +33,27 @@ agentic_workflow_examples
 - Build: (to be determined)
 - Lint: (to be determined)
 
+## 実装ステータス
+
+### PydanticAI (完了)
+- ✅ 基本セットアップ
+- ✅ Google Maps Geocoding API統合
+- ✅ Google Weather API統合
+- ✅ エラーハンドリングとフォールバック機能
+
+### LangChain (進行中)
+- ✅ 基本セットアップ
+- ✅ 地理座標取得機能 (get_city_coordinates tool)
+- 🚧 天気API呼び出し機能 (get_weather_data tool) - 実装完了、PRペンディング
+- ⏳ 統合テストとエラーハンドリング
+
+### Google ADK (未着手)
+- ⏳ 基本セットアップ
+- ⏳ 地理座標取得機能
+- ⏳ 天気API呼び出し機能
+
 ## Notes
-- Repository was recently cloned and appears to be empty
+- 現在はLangChain実装のIssue #18 (天気API呼び出し機能) を作業中
+- Google Weather APIを使用（OpenWeatherMapから変更）
+- 各ライブラリで共通のWeatherAgentインターフェースを使用
 - Working directory: /Users/dandaso/claude_home/agentic_workflow_examples

--- a/langchain/langchain_weather_agent.py
+++ b/langchain/langchain_weather_agent.py
@@ -38,6 +38,10 @@ class LangchainWeatherAgent(WeatherAgent):
 あなたは天気情報を提供する親切なアシスタントです。
 ユーザーから都市名を受け取り、その都市の天気情報を日本語で分かりやすく説明してください。
 
+利用可能なツール:
+- get_city_coordinates: 都市名から地理座標を取得
+- get_weather_data: 座標から詳細な天気情報を取得
+
 質問: {input}
 """)
         
@@ -65,7 +69,26 @@ class LangchainWeatherAgent(WeatherAgent):
                 # エラー時はフォールバック（東京の座標）
                 return {"lat": 35.6762, "lng": 139.6503}
         
-        tools = [get_city_coordinates]
+        @tool
+        def get_weather_data(lat: float, lng: float) -> Dict[str, Any]:
+            """
+            座標から詳細な天気情報を取得します。
+            
+            Args:
+                lat: 緯度
+                lng: 経度
+                
+            Returns:
+                天気データ辞書
+            """
+            try:
+                return self._get_weather_data_real(lat, lng)
+            except Exception as e:
+                print(f"天気APIエラー: {e}")
+                # エラー時はフォールバック（モックデータ）
+                return self._get_weather_data(lat, lng)
+        
+        tools = [get_city_coordinates, get_weather_data]
         return tools
     
     def run(self, city: str) -> str:
@@ -83,8 +106,18 @@ class LangchainWeatherAgent(WeatherAgent):
             get_city_coordinates_tool = self.tools[0]  # get_city_coordinates tool
             coords = get_city_coordinates_tool.invoke(city)
             
-            # LLMに座標情報を含めて質問
-            prompt = f"{city}の天気情報を教えてください。この都市の座標は緯度{coords['lat']}度、経度{coords['lng']}度です。"
+            # ツールを使って天気データを取得
+            get_weather_data_tool = self.tools[1]  # get_weather_data tool
+            weather_data = get_weather_data_tool.invoke({"lat": coords['lat'], "lng": coords['lng']})
+            
+            # LLMに実際の天気データを含めて質問
+            prompt = f"""
+{city}の天気情報を教えてください。
+座標: 緯度{coords['lat']}度、経度{coords['lng']}度
+天気データ: {weather_data['description']}
+
+この情報を元に、分かりやすく日本語で天気情報を説明してください。
+"""
             
             result = self.chain.invoke({"input": prompt})
             return f"[{self.name}] {result.content}"


### PR DESCRIPTION
## Summary
- LangChain Agentに天気API呼び出し機能を実装
- Google Weather APIと統合したLangChainツールを作成
- 実際の天気データをLLMに渡して自然な日本語説明を生成

## 主な変更点
- `get_weather_data`ツールを実装
- Google Weather APIと連携して実際の天気情報を取得
- 地理座標取得と天気データ取得の完全な統合
- エラー時のフォールバック機能（モックデータを使用）
- 実際の天気データを活用したLLMプロンプト生成
- CLAUDE.mdの実装ステータスを更新

## Test plan
- [x] 天気APIツールが正常に初期化される
- [x] Google Weather APIとの統合が動作する
- [x] 座標から天気データが正しく取得される
- [x] 天気データがLLMに正しく渡される
- [x] エラー時のフォールバック機能が動作する

Fixes #18

🤖 Generated with [Claude Code](https://claude.ai/code)